### PR TITLE
remove windows directories from dmenu_path

### DIFF
--- a/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
-  <Identity Name="ArchLinux-Unofficial" Version="1.1.50300.0" Publisher="CN=Alexandre Teoi" ProcessorArchitecture="x64" />
+  <Identity Name="ArchLinux-Unofficial" Version="1.1.50753.0" Publisher="CN=Alexandre Teoi" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Arch Linux - Unofficial</DisplayName>

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ It is possible to install and run the [Sway](https://swaywm.org/) tiling [Waylan
 
 WSLg creates a soft link to the Unix-domain socket `/tmp/.X11-unix` used by [Xorg](https://www.x.org/) for [local network connections](https://www.x.org/archive/X11R6.8.0/doc/Xorg.1.html#sect4). This breaks `wlroots` at <https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/0.15.1/xwayland/sockets.c#L94-97>.
 
+### Sway installation
+
 The script [`2-sway.sh`](./scripts/2-sway.sh) installs Sway with the required dependencies and applies a [patch](./scripts/2-wsl-wlroots.sh) to the `wlroots` library to fix that issue with WSLg. It also configures Sway to run in headless mode with a slightly modified version of the [default configuration file](https://github.com/swaywm/sway/blob/v1.7/config.in):
 
 - Set _ALT_ as the modifier key
@@ -89,11 +91,22 @@ The installation process creates the script `~/.local/bin/s` to launch Sway with
 
 Audio support is provided by [PipeWire](https://pipewire.org/) and the [WSLg PulseAudio plugin](https://github.com/microsoft/wslg#pulse-audio-plugin).
 
+### dmenu
+
+WSL appends the Windows' `PATH` to your distro's one. If the `PATH` is too large, it may take a long time to open the default application launcher [`dmenu`](https://tools.suckless.org/dmenu/) in Sway. A workaround is to [disable the `PATH` appending feature](https://docs.microsoft.com/windows/wsl/wsl-config#interop-settings) in your `/etc/wsl.conf` configuration file.
+
+```ini
+[interop]
+appendWindowsPath = false
+```
+
+If you need to keep the Windows PATH in WSL, you can patch `dmenu` to exclude the search for executables in the Windows directories. The script [`2-wsl-dmenu.sh`](./scripts/2-wsl-dmenu.sh) implements this workaround.
+
 ## Customize the image
 
-You can package your own custom image with the following steps. More details are available at <https://docs.microsoft.com/windows/wsl/use-custom-distro#import-the-tar-file-into-wsl>
+You can package your own custom image with the following steps. More details are available at <https://docs.microsoft.com/windows/wsl/use-custom-distro#import-the-tar-file-into-wsl>.
 
-1. Create a folder to store the distribution (for example, `C:\wslDistroStorage\ArchLinux`)
+1. Create a folder to store the distribution (for example, `C:\wslDistroStorage\ArchLinux`).
 1. Download one of the images available at <https://gitlab.archlinux.org/archlinux/archlinux-docker/-/releases>. Extract the `tar` file to any folder and run the following command to import it to WSL:
 
     ```powershell
@@ -144,7 +157,7 @@ Open the main solution `DistroLauncher.sln` with Visual Studio and generate a te
 Create a sub-folder with name `x64` in the root folder of this project and copy the customized `image.tar.gz` file to it.
 
 ```powershell
-PS C:\repos\WSL-DistroLauncher> tree /F
+PS C:\repos\archlinux-wsl> tree /F
 Folder PATH listing
 C:.
 │   .gitignore

--- a/scripts/2-wsl-dmenu.sh
+++ b/scripts/2-wsl-dmenu.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Exclude Windows paths from dmenu.
+# https://wiki.archlinux.org/title/Patching_packages
+
+set -o errexit -o nounset
+
+mkdir -p "${HOME}/patches/dmenu"
+pushd .
+cd "${HOME}/patches/dmenu" || exit 1
+
+cat << END > PKGBUILD
+# Maintainer: Levente Polyak <anthraxx[at]archlinux[dot]org>
+# Contributor: Sergej Pupykin <pupykin.s+arch@gmail.com>
+# Contributor: Bartłomiej Piotrowski <bpiotrowski@archlinux.org>
+# Contributor: Thorsten Töpper <atsutane-tu@freethoughts.de>
+# Contributor: Thayer Williams <thayer@archlinux.org>
+# Contributor: Jeff 'codemac' Mickey <jeff@archlinux.org>
+
+pkgname=dmenu
+pkgver=5.1
+pkgrel=1
+pkgdesc='Generic menu for X'
+url='https://tools.suckless.org/dmenu/'
+arch=('x86_64')
+license=('MIT')
+depends=('sh' 'glibc' 'coreutils' 'libx11' 'libxinerama' 'libxft' 'freetype2' 'fontconfig' 'libfontconfig.so')
+source=(https://dl.suckless.org/tools/dmenu-\${pkgver}.tar.gz nowindows.patch)
+sha512sums=('2f950c30e15880e6081e04d73dd0cf8f402f52d793a77d22c3f10739bfed6222a9c4e7ec8eb3fc676422fea09e30b8cf9789f67b276b22c398c96f5ed3b56453'
+            'b49166745833e7d4bebd38c5c378534a77be57024a9f1dc5a710e3b13019e6c3e45e637a2d02136733488b843bf58d14793a30fdf3c81fe53b637f597b664e68')
+b2sums=('22132d851c37c6fd7b08ce1087cb33278f3194412cc590b196831568f7fc0b25e1b7a98b83720fcd5df1f8bae095ea7405b96003a698038599b1f25b58aa8a3c'
+        '2d4a0e8e6a195bc1f003e593c55d5baf175e0c63498b959b017498aa5079e71ae980e83f484097b2d8c3b44431afd4b5f291a08fb18da88a2379d14d471167d1')
+
+prepare() {
+  cd \${pkgname}-\${pkgver}
+  echo "CPPFLAGS+=\${CPPFLAGS}" >> config.mk
+  echo "CFLAGS+=\${CFLAGS}" >> config.mk
+  echo "LDFLAGS+=\${LDFLAGS}" >> config.mk
+  patch --forward --strip=1 --input="\${srcdir}/nowindows.patch"
+}
+
+build() {
+  cd \${pkgname}-\${pkgver}
+  make \
+	  X11INC=/usr/include/X11 \
+	  X11LIB=/usr/lib/X11 \
+	  FREETYPEINC=/usr/include/freetype2
+}
+
+package() {
+  cd \${pkgname}-\${pkgver}
+  make PREFIX=/usr DESTDIR="\${pkgdir}" install
+  install -Dm 644 LICENSE -t "\${pkgdir}/usr/share/licenses/\${pkgname}"
+}
+
+# vim: ts=2 sw=2 et:
+END
+
+cat << END > nowindows.patch
+diff --unified --recursive --text package.orig/dmenu_path package.new/dmenu_path
+--- package.orig/dmenu_path	2022-03-22 22:37:07.004742900 -0300
++++ package.new/dmenu_path	2022-03-22 22:39:00.944742900 -0300
+@@ -5,9 +5,12 @@
+ 
+ [ ! -e "\$cachedir" ] && mkdir -p "\$cachedir"
+ 
++PATHNOWINDOWS=\$(echo "\${PATH}" \\
++	| sed 's/\\/mnt\\/[[:alpha:]]\\/[^:]*\\(:\\|\$\\)//g' | sed 's/:\$//')
++
+ IFS=:
+-if stest -dqr -n "\$cache" \$PATH; then
+-	stest -flx \$PATH | sort -u | tee "\$cache"
++if stest -dqr -n "\$cache" \$PATHNOWINDOWS; then
++	stest -flx \$PATHNOWINDOWS | sort -u | tee "\$cache"
+ else
+ 	cat "\$cache"
+ fi
+END
+
+makepkg
+sudo pacman -U --noconfirm dmenu-*-x86_64.pkg.tar.zst
+
+popd || exit 1


### PR DESCRIPTION
WSL appends the Windows' PATH to your distro's one. If the PATH is too large, it may take a long time to open dmenu in Sway.